### PR TITLE
v0.4.2.3: fix "non-canoncial mappend" warnings, bump dependencies

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.16.6.20230729
+# version: 0.17.20230827
 #
-# REGENDATA ("0.16.6.20230729",["github","blaze-builder.cabal"])
+# REGENDATA ("0.17.20230827",["github","blaze-builder.cabal"])
 #
 name: Haskell-CI
 on:
@@ -32,14 +32,19 @@ jobs:
     strategy:
       matrix:
         include:
+          - compiler: ghc-9.8.0.20230822
+            compilerKind: ghc
+            compilerVersion: 9.8.0.20230822
+            setup-method: ghcup
+            allow-failure: true
           - compiler: ghc-9.6.2
             compilerKind: ghc
             compilerVersion: 9.6.2
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.4.5
+          - compiler: ghc-9.4.7
             compilerKind: ghc
-            compilerVersion: 9.4.5
+            compilerVersion: 9.4.7
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.2.8
@@ -117,6 +122,7 @@ jobs:
             mkdir -p "$HOME/.ghcup/bin"
             curl -sL https://downloads.haskell.org/ghcup/0.1.19.5/x86_64-linux-ghcup-0.1.19.5 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
+            "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.7.yaml;
             "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
             "$HOME/.ghcup/bin/ghcup" install cabal 3.10.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           else
@@ -126,6 +132,7 @@ jobs:
             mkdir -p "$HOME/.ghcup/bin"
             curl -sL https://downloads.haskell.org/ghcup/0.1.19.5/x86_64-linux-ghcup-0.1.19.5 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
+            "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.7.yaml;
             "$HOME/.ghcup/bin/ghcup" install cabal 3.10.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           fi
         env:
@@ -140,10 +147,12 @@ jobs:
           echo "CABAL_CONFIG=$HOME/.cabal/config" >> "$GITHUB_ENV"
           HCDIR=/opt/$HCKIND/$HCVER
           if [ "${{ matrix.setup-method }}" = ghcup ]; then
-            HC=$HOME/.ghcup/bin/$HCKIND-$HCVER
+            HC=$("$HOME/.ghcup/bin/ghcup" whereis ghc "$HCVER")
+            HCPKG=$(echo "$HC" | sed 's#ghc$#ghc-pkg#')
+            HADDOCK=$(echo "$HC" | sed 's#ghc$#haddock#')
             echo "HC=$HC" >> "$GITHUB_ENV"
-            echo "HCPKG=$HOME/.ghcup/bin/$HCKIND-pkg-$HCVER" >> "$GITHUB_ENV"
-            echo "HADDOCK=$HOME/.ghcup/bin/haddock-$HCVER" >> "$GITHUB_ENV"
+            echo "HCPKG=$HCPKG" >> "$GITHUB_ENV"
+            echo "HADDOCK=$HADDOCK" >> "$GITHUB_ENV"
             echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.1.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           else
             HC=$HCDIR/bin/$HCKIND
@@ -157,7 +166,7 @@ jobs:
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
-          echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
+          if [ $((HCNUMVER >= 90800)) -ne 0 ] ; then echo "HEADHACKAGE=true" >> "$GITHUB_ENV" ; else echo "HEADHACKAGE=false" >> "$GITHUB_ENV" ; fi
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
           echo "GHCJSARITH=0" >> "$GITHUB_ENV"
         env:
@@ -186,6 +195,18 @@ jobs:
           repository hackage.haskell.org
             url: http://hackage.haskell.org/
           EOF
+          if $HEADHACKAGE; then
+          cat >> $CABAL_CONFIG <<EOF
+          repository head.hackage.ghc.haskell.org
+             url: https://ghc.gitlab.haskell.org/head.hackage/
+             secure: True
+             root-keys: 7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
+                        26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
+                        f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
+             key-threshold: 3
+          active-repositories: hackage.haskell.org, head.hackage.ghc.haskell.org:override
+          EOF
+          fi
           cat >> $CABAL_CONFIG <<EOF
           program-default-options
             ghc-options: $GHCJOBS +RTS -M3G -RTS
@@ -236,8 +257,13 @@ jobs:
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "package blaze-builder" >> cabal.project ; fi
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
           cat >> cabal.project <<EOF
+          allow-newer: bytestring
+          allow-newer: text
           EOF
-          $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: $_ installed\n" unless /^(blaze-builder|text)$/; }' >> cabal.project.local
+          if $HEADHACKAGE; then
+          echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1,/g')" >> cabal.project
+          fi
+          $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: $_ installed\n" unless /^(blaze-builder)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local
       - name: dump install plan
@@ -272,8 +298,25 @@ jobs:
           $CABAL v2-haddock --disable-documentation --haddock-all $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all
       - name: unconstrained build
         run: |
+          if [ $((HCNUMVER >= 70400)) -ne 0 ] ; then rm -f cabal.project.local ; fi
+          if [ $((HCNUMVER >= 70400)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks all ; fi
+      - name: prepare for constraint sets
+        run: |
           rm -f cabal.project.local
-          $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks all
+      - name: constraint set text-2.1
+        run: |
+          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='text ^>= 2.1' all --dry-run ; fi
+          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then cabal-plan topo | sort ; fi
+          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='text ^>= 2.1' --dependencies-only -j2 all ; fi
+          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='text ^>= 2.1' all ; fi
+          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then $CABAL v2-test $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='text ^>= 2.1' all ; fi
+      - name: constraint set bytestring-0.12
+        run: |
+          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='bytestring ^>= 0.12' all --dry-run ; fi
+          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then cabal-plan topo | sort ; fi
+          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='bytestring ^>= 0.12' --dependencies-only -j2 all ; fi
+          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='bytestring ^>= 0.12' all ; fi
+          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then $CABAL v2-test $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='bytestring ^>= 0.12' all ; fi
       - name: save cache
         uses: actions/cache/save@v3
         if: always()

--- a/.gitignore
+++ b/.gitignore
@@ -4,9 +4,11 @@ dist-newstyle/
 *.hi
 *.pdf
 *.png
+.ghc.environment.*
 
 cabal-dev/
 cabal.sandbox.config
+cabal.project.local
 
 benchmarks/BlazeVsBinary
 benchmarks/ChunkedWrite

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,9 @@
+* 0.4.2.3 2023-08-27
+  - Fix compilation warnings concerning non-canonical mappend
+  - Support bytestring-0.12
+  - Support text-2.1
+  - Tested with GHC 7.0.4 to 9.8.1 alpha3
+
 * 0.4.2.2
   - Support GHC 9.2
 

--- a/blaze-builder.cabal
+++ b/blaze-builder.cabal
@@ -1,5 +1,5 @@
 Name:                blaze-builder
-Version:             0.4.2.2
+Version:             0.4.2.3
 Synopsis:            Efficient buffered output.
 
 Description:
@@ -33,8 +33,9 @@ Build-type:          Simple
 Cabal-version:       >= 1.10
 
 Tested-with:
+  GHC == 9.8.0
   GHC == 9.6.2
-  GHC == 9.4.5
+  GHC == 9.4.7
   GHC == 9.2.8
   GHC == 9.0.2
   GHC == 8.10.7
@@ -83,11 +84,11 @@ Library
                      Blaze.ByteString.Builder.Internal.Write
 
   build-depends:
-      base == 4.*
-    , bytestring >= 0.9 && < 1.0
+      base       >= 4.3  && < 5
+    , bytestring >= 0.9  && < 1
     , deepseq
     , ghc-prim
-    , text >= 0.10 && < 2.1
+    , text       >= 0.10 && < 3
 
   if impl(ghc < 7.8)
      build-depends:  bytestring-builder

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -1,2 +1,21 @@
 branches: master
-installed: +all -text
+installed: +all
+
+constraint-set bytestring-0.12
+  ghc: >= 8.2
+  constraints: bytestring ^>= 0.12
+  tests: True
+  run-tests: True
+
+constraint-set text-2.1
+  ghc: >= 8.2
+  constraints: text ^>= 2.1
+  tests: True
+  run-tests: True
+
+raw-project
+  allow-newer: bytestring
+  allow-newer: text
+
+-- The allow-newer ruins the unconstrained build with GHC 7.0.4
+unconstrained: >=7.4


### PR DESCRIPTION
https://hackage.haskell.org/package/blaze-builder-0.4.2.3/candidate