### PR TITLE
Fix computation of max*BufferOverhead on 32 bit platforms

### DIFF
--- a/Blaze/ByteString/Builder/HTTP.hs
+++ b/Blaze/ByteString/Builder/HTTP.hs
@@ -129,8 +129,8 @@ chunkedTransferEncoding innerBuilder =
               return $ bufferFull minimalBufferSize op (go innerStep)
           | otherwise = do
               let !brInner@(BufferRange opInner _) = BufferRange
-                     (op  `plusPtr` (chunkSizeLength + 2))     -- leave space for chunk header
-                     (ope `plusPtr` (-maxAfterBufferOverhead)) -- leave space at end of data
+                     (op  `plusPtr` (chunkSizeLength + crlfLength)) -- leave space for chunk header
+                     (ope `plusPtr` (-maxAfterBufferOverhead))      -- leave space at end of data
 
                   -- wraps the chunk, if it is non-empty, and returns the
                   -- signal constructed with the correct end-of-data pointer
@@ -143,9 +143,9 @@ chunkedTransferEncoding innerBuilder =
                         pokeWord32HexN chunkSizeLength
                             (fromIntegral $ opInner' `minusPtr` opInner)
                             op
-                        execWrite writeCRLF (opInner `plusPtr` (-2))
+                        execWrite writeCRLF (opInner `plusPtr` (-crlfLength))
                         execWrite writeCRLF opInner'
-                        mkSignal (opInner' `plusPtr` 2)
+                        mkSignal (opInner' `plusPtr` crlfLength)
 
                   -- prepare handlers
                   doneH opInner' _ = wrapChunk opInner' $ \op' -> do


### PR DESCRIPTION
This basically has the same effect as the following fix from bsb-http-chunked and should prevent edge cases where buffers aren't big enough on 32 bit platforms.
https://github.com/sjakobi/bsb-http-chunked/commit/dde7c9fa33bb6e55b44c5f3e3024215475f64d4c