### PR TITLE
v0.4.3

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.19.20250330
+# version: 0.19.20250506
 #
-# REGENDATA ("0.19.20250330",["github","blaze-builder.cabal"])
+# REGENDATA ("0.19.20250506",["github","blaze-builder.cabal"])
 #
 name: Haskell-CI
 on:
@@ -37,9 +37,9 @@ jobs:
             compilerVersion: 9.12.2
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.10.1
+          - compiler: ghc-9.10.2
             compilerKind: ghc
-            compilerVersion: 9.10.1
+            compilerVersion: 9.10.2
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.8.4
@@ -110,8 +110,8 @@ jobs:
           chmod a+x "$HOME/.ghcup/bin/ghcup"
       - name: Install cabal-install
         run: |
-          "$HOME/.ghcup/bin/ghcup" install cabal 3.14.1.1-p1 || (cat "$HOME"/.ghcup/logs/*.* && false)
-          echo "CABAL=$HOME/.ghcup/bin/cabal-3.14.1.1-p1 -vnormal+nowrap" >> "$GITHUB_ENV"
+          "$HOME/.ghcup/bin/ghcup" install cabal 3.14.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+          echo "CABAL=$HOME/.ghcup/bin/cabal-3.14.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
       - name: Install GHC (GHCup)
         if: matrix.setup-method == 'ghcup'
         run: |

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -22,8 +22,8 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         plan:
-          - ghc: '9.10.1'
-            resolver: 'nightly-2025-05-02'
+          - ghc: '9.10.2'
+            resolver: 'nightly-2025-05-15'
           - ghc: '9.8.4'
             resolver: 'lts-23.20'
           - ghc: '9.6.7'
@@ -46,8 +46,8 @@ jobs:
         include:
           - os: windows-latest
             plan:
-              resolver: 'nightly-2025-05-02'
-              ghc: '9.10.1'
+              resolver: 'nightly-2025-05-15'
+              ghc: '9.10.2'
           - os: windows-latest
             plan:
               resolver: 'lts-22.44'
@@ -55,8 +55,8 @@ jobs:
 
           - os: macos-latest
             plan:
-              resolver: 'nightly-2025-05-02'
-              ghc: '9.10.1'
+              resolver: 'nightly-2025-05-15'
+              ghc: '9.10.2'
           - os: macos-latest
             plan:
               resolver: 'lts-22.44'

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,8 @@
-* Unreleased
+* 0.4.3 2025-05-15
+  - Fix computation of max buffer overhead on 32 bit platforms
+    (sternenseemann, PR #8 https://github.com/blaze-builder/blaze-builder/pull/8)
   - Drop support for GHC 7, bytestring < 0.10.4 and text < 1.1.2
+  - Tested with GHC 8.0 - 9.12.2
 
 * 0.4.2.3 2023-08-27
   - Fix compilation warnings concerning non-canonical mappend

--- a/blaze-builder.cabal
+++ b/blaze-builder.cabal
@@ -1,5 +1,5 @@
 Name:                blaze-builder
-Version:             0.4.2.3
+Version:             0.4.3
 Synopsis:            Efficient buffered output.
 
 Description:

--- a/blaze-builder.cabal
+++ b/blaze-builder.cabal
@@ -34,7 +34,7 @@ Cabal-version:       >= 1.10
 
 Tested-with:
   GHC == 9.12.2
-  GHC == 9.10.1
+  GHC == 9.10.2
   GHC == 9.8.4
   GHC == 9.6.7
   GHC == 9.4.8


### PR DESCRIPTION
- **Bump CI from 9.10.1 to 9.10.2**
  

- **Bump to 0.4.3 and CHANGELOG**

Candidate: https://hackage.haskell.org/package/blaze-builder-0.4.3/candidate
  