### PR TITLE
v0.4.4.1: drop unused dependencies

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.19.20250506
+# version: 0.19.20250821
 #
-# REGENDATA ("0.19.20250506",["github","blaze-builder.cabal"])
+# REGENDATA ("0.19.20250821",["github","blaze-builder.cabal"])
 #
 name: Haskell-CI
 on:
@@ -32,6 +32,11 @@ jobs:
     strategy:
       matrix:
         include:
+          - compiler: ghc-9.14.0.20250819
+            compilerKind: ghc
+            compilerVersion: 9.14.0.20250819
+            setup-method: ghcup-prerelease
+            allow-failure: false
           - compiler: ghc-9.12.2
             compilerKind: ghc
             compilerVersion: 9.12.2
@@ -110,11 +115,26 @@ jobs:
           chmod a+x "$HOME/.ghcup/bin/ghcup"
       - name: Install cabal-install
         run: |
-          "$HOME/.ghcup/bin/ghcup" install cabal 3.14.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
-          echo "CABAL=$HOME/.ghcup/bin/cabal-3.14.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+          "$HOME/.ghcup/bin/ghcup" install cabal 3.16.0.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+          echo "CABAL=$HOME/.ghcup/bin/cabal-3.16.0.0 -vnormal+nowrap" >> "$GITHUB_ENV"
       - name: Install GHC (GHCup)
         if: matrix.setup-method == 'ghcup'
         run: |
+          "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
+          HC=$("$HOME/.ghcup/bin/ghcup" whereis ghc "$HCVER")
+          HCPKG=$(echo "$HC" | sed 's#ghc$#ghc-pkg#')
+          HADDOCK=$(echo "$HC" | sed 's#ghc$#haddock#')
+          echo "HC=$HC" >> "$GITHUB_ENV"
+          echo "HCPKG=$HCPKG" >> "$GITHUB_ENV"
+          echo "HADDOCK=$HADDOCK" >> "$GITHUB_ENV"
+        env:
+          HCKIND: ${{ matrix.compilerKind }}
+          HCNAME: ${{ matrix.compiler }}
+          HCVER: ${{ matrix.compilerVersion }}
+      - name: Install GHC (GHCup prerelease)
+        if: matrix.setup-method == 'ghcup-prerelease'
+        run: |
+          "$HOME/.ghcup/bin/ghcup" config add-release-channel prereleases
           "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
           HC=$("$HOME/.ghcup/bin/ghcup" whereis ghc "$HCVER")
           HCPKG=$(echo "$HC" | sed 's#ghc$#ghc-pkg#')
@@ -136,7 +156,7 @@ jobs:
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
-          echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
+          if [ $((HCNUMVER >= 91400)) -ne 0 ] ; then echo "HEADHACKAGE=true" >> "$GITHUB_ENV" ; else echo "HEADHACKAGE=false" >> "$GITHUB_ENV" ; fi
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
         env:
           HCKIND: ${{ matrix.compilerKind }}
@@ -164,6 +184,18 @@ jobs:
           repository hackage.haskell.org
             url: http://hackage.haskell.org/
           EOF
+          if $HEADHACKAGE; then
+          cat >> $CABAL_CONFIG <<EOF
+          repository head.hackage.ghc.haskell.org
+             url: https://ghc.gitlab.haskell.org/head.hackage/
+             secure: True
+             root-keys: 7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
+                        26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
+                        f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
+             key-threshold: 3
+          active-repositories: hackage.haskell.org, head.hackage.ghc.haskell.org:override
+          EOF
+          fi
           cat >> $CABAL_CONFIG <<EOF
           program-default-options
             ghc-options: $GHCJOBS +RTS -M3G -RTS
@@ -212,9 +244,16 @@ jobs:
           touch cabal.project.local
           echo "packages: ${PKGDIR_blaze_builder}" >> cabal.project
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "package blaze-builder" >> cabal.project ; fi
-          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods -Werror=missing-fields" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90400)) -ne 0 ] ; then echo "package blaze-builder" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90400)) -ne 0 ] ; then echo "    ghc-options: -Werror=unused-packages" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90000)) -ne 0 ] ; then echo "package blaze-builder" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90000)) -ne 0 ] ; then echo "    ghc-options: -Werror=incomplete-patterns -Werror=incomplete-uni-patterns" >> cabal.project ; fi
           cat >> cabal.project <<EOF
           EOF
+          if $HEADHACKAGE; then
+          echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1,/g')" >> cabal.project
+          fi
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: any.$_ installed\n" unless /^(blaze-builder)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -22,10 +22,12 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         plan:
+          - ghc: '9.12.2'
+            resolver: 'nightly-2025-08-27'
           - ghc: '9.10.2'
-            resolver: 'nightly-2025-05-15'
+            resolver: 'lts-24.7'
           - ghc: '9.8.4'
-            resolver: 'lts-23.20'
+            resolver: 'lts-23.28'
           - ghc: '9.6.7'
             resolver: 'lts-22.44'
           - ghc: '9.4.8'
@@ -46,8 +48,8 @@ jobs:
         include:
           - os: windows-latest
             plan:
-              resolver: 'nightly-2025-05-15'
-              ghc: '9.10.2'
+              resolver: 'nightly-2025-08-27'
+              ghc: '9.12.2'
           - os: windows-latest
             plan:
               resolver: 'lts-22.44'
@@ -55,8 +57,8 @@ jobs:
 
           - os: macos-latest
             plan:
-              resolver: 'nightly-2025-05-15'
-              ghc: '9.10.2'
+              resolver: 'nightly-2025-08-27'
+              ghc: '9.12.2'
           - os: macos-latest
             plan:
               resolver: 'lts-22.44'

--- a/Blaze/ByteString/Builder/HTTP.hs
+++ b/Blaze/ByteString/Builder/HTTP.hs
@@ -44,7 +44,8 @@ import qualified Blaze.ByteString.Builder.Char8 as Char8
 shiftr_w32 :: Word32 -> Int -> Word32
 
 #if defined(__GLASGOW_HASKELL__) && !defined(__HADDOCK__)
-#if MIN_VERSION_ghc_prim(0,8,0)
+#if MIN_VERSION_base(4,16,0)
+-- base >= 4.16 proxy for GHC >= 9.2 which fixes ghc-prim >= 0.8
 shiftr_w32 (W32# w) (I# i) = W32# (wordToWord32# ((word32ToWord# w) `uncheckedShiftRL#` i))
 #else
 shiftr_w32 (W32# w) (I# i) = W32# (w `uncheckedShiftRL#`   i)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+* 0.4.4.1 2025-08-28
+  - Drop unused dependency `deepseq`
+  - Tested with GHC 8.0 - 9.14 alpha1
+
 * 0.4.4 2025-07-31
   - Optimization:
     `Blaze.ByteString.Builder.Char.Utf8.fromText = Data.Text.Encoding.encodeUtf8Builder`

--- a/blaze-builder.cabal
+++ b/blaze-builder.cabal
@@ -84,7 +84,6 @@ Library
   build-depends:
       base       >= 4.9    && < 5
     , bytestring >= 0.10.4 && < 1
-    , deepseq
     , ghc-prim
     , text       >= 1.1.2  && < 3
 

--- a/blaze-builder.cabal
+++ b/blaze-builder.cabal
@@ -33,6 +33,7 @@ Category:            Data
 Build-type:          Simple
 
 Tested-with:
+  GHC == 9.14.1
   GHC == 9.12.2
   GHC == 9.10.2
   GHC == 9.8.4

--- a/blaze-builder.cabal
+++ b/blaze-builder.cabal
@@ -84,7 +84,6 @@ Library
   build-depends:
       base       >= 4.9    && < 5
     , bytestring >= 0.10.4 && < 1
-    , ghc-prim
     , text       >= 1.1.2  && < 3
 
   ghc-options:

--- a/blaze-builder.cabal
+++ b/blaze-builder.cabal
@@ -1,6 +1,6 @@
 Cabal-version:       1.18
 Name:                blaze-builder
-Version:             0.4.4
+Version:             0.4.4.1
 Synopsis:            Efficient buffered output.
 
 Description:


### PR DESCRIPTION
- **Drop unused dependency deepseq**
  

- **Drop fake dependency ghc-prim by using MIN_VERSION_base instead of ...ghc_prim**
  

- **Bump Haskell CI to GHC 9.14 alpha1**
  

- **Bump to 0.4.4.1 and CHANGELOG**

Candidate: http://hackage.haskell.org/package/blaze-builder-0.4.4.1/candidate
  